### PR TITLE
Ignore disabled storage path errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@otchy/home-tube",
-    "version": "0.9.20",
+    "version": "0.9.21",
     "description": "HomeTube provides YouTube-ish UI and features for your videos in your local storage and local network.",
     "bin": {
         "home-tube": "bin/home-tube"


### PR DESCRIPTION
## Summary
- filter validation errors for storages disabled in the config
- propagate filtered errors via `isAppConfigValidationErrors`
- rename `StorageValidatinErrors` type to `StorageValidationErrors`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6874e35bff388330a0cfd94cc89ecec5