### PR TITLE
feat: allow closing snapshot preview with Escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@otchy/home-tube",
-    "version": "0.9.21",
+    "version": "0.9.22",
     "description": "HomeTube provides YouTube-ish UI and features for your videos in your local storage and local network.",
     "bin": {
         "home-tube": "bin/home-tube"

--- a/src/components/video-player/SnapshotPreview.tsx
+++ b/src/components/video-player/SnapshotPreview.tsx
@@ -92,6 +92,19 @@ const SnapshotPreview: React.FC<Props> = ({ show, setShow, details, video, updat
     const onHide = () => {
         setShow(false);
     };
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                onHide();
+            }
+        };
+        if (show) {
+            document.addEventListener('keydown', onKeyDown);
+        }
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [show]);
     const onUpdate = () => {
         if (canvasRef.current) {
             setSubmitting(true);


### PR DESCRIPTION
## Summary
- allow SnapshotPreview modal to close when Escape key is pressed

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a529c773f48330b3bb865a573a85b1